### PR TITLE
Nil safety check.

### DIFF
--- a/Foursquare2/Foursquare2.m
+++ b/Foursquare2/Foursquare2.m
@@ -93,10 +93,13 @@ static NSMutableDictionary *attributes;
 }
 
 + (void)setAccessToken:(NSString *)token {
-	[self classAttributes][kFOURSQUARE_ACCESS_TOKEN] = token;
-	[[NSUserDefaults standardUserDefaults] setObject:token
+  if (token)
+  {
+    [self classAttributes][kFOURSQUARE_ACCESS_TOKEN] = token;
+    [[NSUserDefaults standardUserDefaults] setObject:token
                                               forKey:@"FOURSQUARE_ACCESS_TOKEN"];
-	[[NSUserDefaults standardUserDefaults] synchronize];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+  }
 }
 
 + (void)removeAccessToken {


### PR DESCRIPTION
For some reason the token sometimes comes through as `nil` even with a response error code of `FSOAuthErrorNone`. This check prevents a crash in that case.
