### PR TITLE
Add check for nil auth callback

### DIFF
--- a/Foursquare2/Foursquare2.m
+++ b/Foursquare2/Foursquare2.m
@@ -1460,6 +1460,8 @@ static NSMutableDictionary *attributes;
 
 
 + (void)authorizeWithCallback:(Foursquare2Callback)callback {
+    NSAssert([Foursquare2 sharedInstance].authorizationCallback == nil, @"Resetting callback that has not been called");
+
 	[Foursquare2 sharedInstance].authorizationCallback = [callback copy];
     
     if ([[Foursquare2 sharedInstance] nativeAuthorization]) {


### PR DESCRIPTION
I have seen several `EXC_BAD_ACCESS KERN_INVALID_ADDRESS at 0x0000000000000010` in `+[Foursquare2 callAuthorizationCallbackWithError:]` (`Foursquare2.m,`, line 1470). I assume this is caused my multiple concurrent requests and a race condition that causes the callback to be set to `nil` by one thread and then access by another. Guarded against the `nil` callback and added an `NSAssert` for dev builds to fail-fast.
