### PR TITLE
fixed syntax error

### DIFF
--- a/Foursquare-API-v2.podspec
+++ b/Foursquare-API-v2.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/Constantine-Fry/Foursquare-API-v2"
   s.screenshots  = "https://raw.github.com/Constantine-Fry/Foursquare-API-v2/master/img/photo2.PNG"
   s.license      = 'MIT'
-  s.author       = { "Constantine Fry" }
+  s.author       = 'Constantine Fry'
   s.source       = { :git => "https://github.com/Constantine-Fry/Foursquare-API-v2.git", :tag => "1.4.6" }
   s.platform     = :ios, '5.0'
   s.source_files = 'Classes', 'Foursquare2/**/*.{h,m}'


### PR DESCRIPTION
No brackets if no email is present 

```
$ [!] Invalid `Foursquare-API-v2.podspec` 8: syntax error, unexpected '}', expecting =>
```
