### PR TITLE
Nil the error in case there is none, else it would always go to the error fallback

### DIFF
--- a/Foursquare2/FSOperation.m
+++ b/Foursquare2/FSOperation.m
@@ -63,6 +63,8 @@
                 error = [NSError errorWithDomain:kFoursquare2ErrorDomain
                                             code:[result[@"meta"][@"code"] integerValue]
                                         userInfo:userInfo];
+            } else { // NIL the error in the other case
+                error = nil;
             }
         }
     }


### PR DESCRIPTION
The error get sets to an empty value, I believe it's when you pass it to the NSUrlConnection request.

I put the error to nil when the JSONSerialization has not failed. Not sure if setting it to nil on creation would fix the bug. We could also change the check at line 79.
