### PR TITLE
Added a /users/<userID>/following so we can get a proper following list

### DIFF
--- a/Foursquare2/Foursquare2.h
+++ b/Foursquare2/Foursquare2.h
@@ -264,6 +264,16 @@ FOUNDATION_EXPORT NSString * const kFoursquare2DidRemoveAccessTokenNotification;
                        callback:(Foursquare2Callback)callback;
 
 /**
+ This is an undocumented API. This returns the list of users that a given user is following
+ @param userID The user whose following list we are interested in
+ @param offset The offset at which to start
+ @returns a list of users and a count of total users said user is following
+ */
++ (NSOperation *)userGetFollowing:(NSString *)userID
+                        offset:(NSNumber *)offset
+                       callback:(Foursquare2Callback)callback;
+
+/**
  @param userID Valid user ID to get tips from. Pass "self" to get tips of the acting user.
  @param limit Number of result to return, up to 250.
  @param offset The number of results to skip. Used for paging.

--- a/Foursquare2/Foursquare2.m
+++ b/Foursquare2/Foursquare2.m
@@ -228,6 +228,14 @@ static NSMutableDictionary *attributes;
     return [self sendGetRequestWithPath:path parameters:parameters callback:callback];
 }
 
++ (NSOperation *)userGetFollowing:(NSString *)userID
+                           offset:(NSNumber *)offset
+                         callback:(Foursquare2Callback)callback {
+    NSString *path = [NSString stringWithFormat:@"users/%@/following",userID];
+    NSMutableDictionary *parameters = [@{@"m" : @"foursquare"} mutableCopy];
+    return [self sendGetRequestWithPath:path parameters:parameters callback:callback];
+}
+
 + (NSOperation *)userGetTips:(NSString *)userID
                        limit:(NSNumber *)limit
                       offset:(NSNumber *)offset
@@ -301,9 +309,9 @@ static NSMutableDictionary *attributes;
                           callback:(Foursquare2Callback)callback {
     NSAssert([userIDs count] <= 5, @"Multi does not work with more than 5 methods at a time");
     NSString *path = @"multi?requests=/users/";
-    NSString *multiParameters = [userIDs componentsJoinedByString:@"/lists,/users/"];
-    path = [[path stringByAppendingString:multiParameters] stringByAppendingString:@"/lists"];
-    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+    NSString *multiParameters = [userIDs componentsJoinedByString:@"/lists?group=created,/users/"];
+    path = [[path stringByAppendingString:multiParameters] stringByAppendingString:@"/lists?group=created&"];
+    NSMutableDictionary *parameters = [@{} mutableCopy];
     return [self sendGetRequestWithPath:path parameters:parameters callback:callback];
 }
 


### PR DESCRIPTION
This is an undocumented API. I talked to folks at Foursquare and they'd
told me about the m=foursquare parameter to get what we're looking for.


The Multi call also needs to have group=created so that we get all created lists, not just 3 of the created, followed etc lists.